### PR TITLE
Integrate NFT flow into Laravel SDK

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.4]
-        laravel: [7.*]
+        php: [8.1]
+        laravel: [8.*]
         dependency-version: [prefer-stable]
         include:
-          - laravel: 7.*
-            testbench: 5.*
+          - laravel: 8.*
+            testbench: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.1]
-        laravel: [8.*]
+        laravel: [9.*]
         dependency-version: [prefer-stable]
         include:
-          - laravel: 8.*
+          - laravel: 9.*
             testbench: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+#        os: [ubuntu-latest, windows-latest] # TODO: fix OS matrix
+        os: [ubuntu-latest]
         php: [8.1]
         laravel: [9.*]
         dependency-version: [prefer-stable]

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,15 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "guzzlehttp/guzzle": "^7.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
-        "orchestra/testbench": "^5.0",
-        "phpunit/phpunit": "^9.3",
-        "psalm/plugin-laravel": "^1.2",
-        "vimeo/psalm": "^3.11"
+        "laravel/legacy-factories": "^v1.3.0",
+        "orchestra/testbench": "^7.6.1",
+        "phpunit/phpunit": "^9.5.21",
+        "vimeo/psalm": "^4.26"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="4"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/src/Http/Client/GuzzleWrapper.php
+++ b/src/Http/Client/GuzzleWrapper.php
@@ -14,6 +14,7 @@ class GuzzleWrapper
                 'Accept' => 'application/json',
                 'x-api-key' => config('hashgraph.secret_key'),
             ],
+            'http_errors' => false
         ]);
     }
 }

--- a/src/LaravelHashgraph.php
+++ b/src/LaravelHashgraph.php
@@ -12,6 +12,16 @@ use Trustenterprises\LaravelHashgraph\Models\AccountHoldingsResponse;
 use Trustenterprises\LaravelHashgraph\Models\AccountTokenBalanceResponse;
 use Trustenterprises\LaravelHashgraph\Models\BequestToken;
 use Trustenterprises\LaravelHashgraph\Models\BequestTokenResponse;
+use Trustenterprises\LaravelHashgraph\Models\NFT\ClaimNft;
+use Trustenterprises\LaravelHashgraph\Models\NFT\ClaimNftResponse;
+use Trustenterprises\LaravelHashgraph\Models\NFT\MintToken;
+use Trustenterprises\LaravelHashgraph\Models\NFT\MintTokenResponse;
+use Trustenterprises\LaravelHashgraph\Models\NFT\NftMetadata;
+use Trustenterprises\LaravelHashgraph\Models\NFT\NftMetadataResponse;
+use Trustenterprises\LaravelHashgraph\Models\NFT\NonFungibleToken;
+use Trustenterprises\LaravelHashgraph\Models\NFT\NonFungibleTokenResponse;
+use Trustenterprises\LaravelHashgraph\Models\NFT\TransferNft;
+use Trustenterprises\LaravelHashgraph\Models\NFT\TransferNftResponse;
 use Trustenterprises\LaravelHashgraph\Models\SendTokenResponse;
 use Trustenterprises\LaravelHashgraph\Models\SendToken;
 use Trustenterprises\LaravelHashgraph\Models\ConsensusMessage;
@@ -20,7 +30,6 @@ use Trustenterprises\LaravelHashgraph\Models\FungibleToken;
 use Trustenterprises\LaravelHashgraph\Models\FungibleTokenResponse;
 use Trustenterprises\LaravelHashgraph\Models\HashgraphTopic;
 use Trustenterprises\LaravelHashgraph\Models\TopicInfo;
-use function Symfony\Component\String\s;
 
 class LaravelHashgraph
 {
@@ -78,6 +87,56 @@ class LaravelHashgraph
     public static function mintFungibleToken(FungibleToken $token) : FungibleTokenResponse
     {
         return static::withAuthenticatedClient()->getClient()->mintFungibleToken($token);
+    }
+
+    /**
+     * Create a NFT from a model
+     *
+     * @throws GuzzleException
+     */
+    public static function createNonFungibleToken(NonFungibleToken $token) : NonFungibleTokenResponse
+    {
+        return static::withAuthenticatedClient()->getClient()->createNft($token);
+    }
+
+    /**
+     * Mint a NFT for a collection
+     *
+     * @throws GuzzleException
+     */
+    public static function mintNonFungibleToken(MintToken $token) : MintTokenResponse
+    {
+        return static::withAuthenticatedClient()->getClient()->mintNft($token->getTokenId(), $token);
+    }
+
+    /**
+     * Generate metadata
+     *
+     * @throws GuzzleException
+     */
+    public static function generateMetadataForNft(NftMetadata $metadata) : NftMetadataResponse
+    {
+        return static::withAuthenticatedClient()->getClient()->createMetadata($metadata);
+    }
+
+    /**
+     * Transfer an NFT to a user
+     *
+     * @throws GuzzleException
+     */
+    public static function transferNonFungibleToken(TransferNft $transferNft) : TransferNftResponse
+    {
+        return static::withAuthenticatedClient()->getClient()->transferNft($transferNft);
+    }
+
+    /**
+     * A user can claim an NFT if they hold the correct pass
+     *
+     * @throws GuzzleException
+     */
+    public static function claimNonFungibleToken(ClaimNft $claimNft) : ClaimNftResponse
+    {
+        return static::withAuthenticatedClient()->getClient()->claimNft($claimNft);
     }
 
     /**

--- a/src/Models/NFT/ClaimNft.php
+++ b/src/Models/NFT/ClaimNft.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+use GuzzleHttp\RequestOptions;
+
+class ClaimNft
+{
+    private String $token_id;
+
+    private String $receiver_id;
+
+    private String $nft_pass_token_id;
+
+    private Int $serial_number;
+
+    /**
+     * ClaimNft constructor.
+     * @param String $token_id
+     * @param String $receiver_id
+     * @param String $nft_pass_token_id
+     * @param Int $serial_number
+     */
+    public function __construct(string $token_id, string $receiver_id, string $nft_pass_token_id, int $serial_number)
+    {
+        $this->token_id = $token_id;
+        $this->receiver_id = $receiver_id;
+        $this->nft_pass_token_id = $nft_pass_token_id;
+        $this->serial_number = $serial_number;
+    }
+
+    public function forRequest(): array
+    {
+        return [
+            RequestOptions::JSON => [
+                'token_id' => $this->getTokenId(),
+                'receiver_id' => $this->getReceiverId(),
+                'nft_pass_token_id' => $this->getNftPassTokenId(),
+                'serial_number' => $this->getSerialNumber()
+            ]
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getTokenId(): string
+    {
+        return $this->token_id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReceiverId(): string
+    {
+        return $this->receiver_id;
+    }
+
+    /**
+     * @return String
+     */
+    public function getNftPassTokenId(): string
+    {
+        return $this->nft_pass_token_id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSerialNumber(): int
+    {
+        return $this->serial_number;
+    }
+}

--- a/src/Models/NFT/ClaimNftResponse.php
+++ b/src/Models/NFT/ClaimNftResponse.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+class ClaimNftResponse
+{
+    private String $serial_number = '';
+
+    private String $receiver_id = '';
+
+    private String $transaction_id = '';
+
+    private array $errors = [];
+
+    private bool $transfer_success = false;
+
+    /**
+     * @param object $response
+     */
+    public function __construct(object $response)
+    {
+        if (property_exists($response, 'errors')) {
+            $this->errors = $response->errors;
+        } else {
+            $this->transfer_success = true;
+            $this->serial_number = $response->data->serial_number;
+            $this->transaction_id = $response->data->transaction_id;
+            $this->receiver_id = $response->data->receiver_id;
+            $this->transaction_id = $response->data->transaction_id;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasTransferSucceeded(): bool
+    {
+        return $this->transfer_success;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return String
+     */
+    public function getSerialNumber(): string
+    {
+        return $this->serial_number;
+    }
+
+    /**
+     * @return String
+     */
+    public function getReceiverId(): string
+    {
+        return $this->receiver_id;
+    }
+
+    /**
+     * @return String
+     */
+    public function getTransactionId(): string
+    {
+        return $this->transaction_id;
+    }
+
+    public function isSuccessful(): bool {
+        return count($this->errors) == 0;
+    }
+}

--- a/src/Models/NFT/MintToken.php
+++ b/src/Models/NFT/MintToken.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+class MintToken
+{
+    private String $token_id;
+
+    private String $cid;
+
+    private ?Int $amount;
+
+    /**
+     * @param String $token_id
+     * @param String $cid
+     * @param ?Int $amount
+     */
+    public function __construct(String $token_id, String $cid, ?Int $amount)
+    {
+        $this->token_id = $token_id;
+        $this->cid = $cid;
+        $this->amount = $amount;
+    }
+
+    public function forRequest(): array
+    {
+        return [
+            'cid' => $this->getCid(),
+            'amount' => $this->getAmount()
+        ];
+    }
+
+    /**
+     * @return String
+     */
+    public function getTokenId(): string
+    {
+        return $this->token_id;
+    }
+
+    /**
+     * @return String
+     */
+    public function getCid(): string
+    {
+        return $this->cid;
+    }
+
+    /**
+     * @return Int|null
+     */
+    public function getAmount(): ?int
+    {
+        return $this->amount;
+    }
+}

--- a/src/Models/NFT/MintTokenResponse.php
+++ b/src/Models/NFT/MintTokenResponse.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+class MintTokenResponse
+{
+    private String $token_id;
+
+    private array $serial_numbers;
+
+    private String $amount;
+
+    private array $errors = [];
+
+    /**
+     * ConsensusMessageResponse constructor, using the http response contents body object
+     * @param object $response
+     */
+    public function __construct(object $response)
+    {
+        if (property_exists($response, 'errors')) {
+            $this->errors = $response->errors;
+        } else {
+            $this->amount = $response->data->amount;
+            $this->serial_numbers = $response->data->minted_serial_numbers;
+            $this->token_id = $response->data->token_id;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return String
+     */
+    public function getTokenId(): string
+    {
+        return $this->token_id;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSerialNumbers(): array
+    {
+        return $this->serial_numbers;
+    }
+
+    /**
+     * @return String
+     */
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+
+    public function isSuccessful(): bool {
+        return count($this->errors) == 0;
+    }
+}

--- a/src/Models/NFT/NftMetadata.php
+++ b/src/Models/NFT/NftMetadata.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+use GuzzleHttp\RequestOptions;
+
+class NftMetadata
+{
+    private array $metadata;
+
+    public function __construct(array $metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function forRequest(): array
+    {
+        return [
+            RequestOptions::JSON => $this->getMetadata()
+        ];
+    }
+
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Models/NFT/NftMetadataResponse.php
+++ b/src/Models/NFT/NftMetadataResponse.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+class NftMetadataResponse
+{
+    private String $cid;
+
+    private array $errors = [];
+
+    private object $meta;
+
+    /**
+     * ConsensusMessageResponse constructor, using the http response contents body object
+     * @param object $response
+     */
+    public function __construct(object $response)
+    {
+        if (property_exists($response, 'errors')) {
+            $this->errors = $response->errors;
+            $this->meta = $response->meta;
+        } else {
+            $this->cid = $response->data->cid;
+        }
+    }
+
+    /**
+     * @return String
+     */
+    public function getCid(): string
+    {
+        return $this->cid;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return object
+     */
+    public function getErrorMeta(): object
+    {
+        return $this->meta;
+    }
+
+    public function isSuccessful(): bool {
+        return count($this->errors) == 0;
+    }
+}

--- a/src/Models/NFT/NonFungibleToken.php
+++ b/src/Models/NFT/NonFungibleToken.php
@@ -1,0 +1,197 @@
+<?php
+
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+class NonFungibleToken
+{
+    private String $symbol;
+
+    private String $name;
+
+    private Int $supply;
+
+    // Optional values below
+    private bool $enable_unsafe_keys = false;
+
+    private bool $has_royalties = true;
+
+    private ?String $royalty_account_id = null;
+
+    private float $royalty_fee = 0.05;
+
+    private float $fallback_fee = 0;
+
+    /**
+     * FungibleToken constructor.
+     * @param String $symbol
+     * @param String $name
+     * @param Int $supply
+     */
+    public function __construct(string $symbol, string $name, Int $supply)
+    {
+        $this->symbol = $symbol;
+        $this->name = $name;
+        $this->supply = $supply;
+    }
+
+    public function forNftRequest(): array
+    {
+        $token_payload = [
+            'symbol' => $this->getSymbol(),
+            'collection_name' => $this->getName(),
+            'supply' => $this->getSupply(),
+        ];
+
+        if ($this->enableUnsafeKeys()) {
+            $token_payload['enable_unsafe_keys'] = true;
+        }
+
+        if ($this->hasRoyalties()) {
+
+            $token_payload['royalty_fee'] = $this->getRoyaltyFee();
+
+            if ($this->getRoyaltyAccountId()) {
+                $token_payload['royalty_account_id'] = $this->getRoyaltyAccountId();
+            }
+
+            if ($this->getFallbackFee() > 0) {
+                $token_payload['fallback_fee'] = $this->getFallbackFee();
+            }
+        }
+
+        return $token_payload;
+    }
+
+    /**
+     * @return String
+     */
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    /**
+     * @param String $symbol
+     */
+    public function setSymbol(string $symbol): void
+    {
+        $this->symbol = $symbol;
+    }
+
+    /**
+     * @return String
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param String $name
+     */
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return String
+     */
+    public function getSupply(): string
+    {
+        return $this->supply;
+    }
+
+    /**
+     * @param String $supply
+     */
+    public function setSupply(string $supply): void
+    {
+        $this->supply = $supply;
+    }
+
+    /**
+     * @return bool
+     */
+    public function enableUnsafeKeys(): bool
+    {
+        return $this->enable_unsafe_keys;
+    }
+
+    /**
+     * @return NonFungibleToken
+     */
+    public function WARNING_enableUnsafeKeys(): self
+    {
+        $this->enable_unsafe_keys = true;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasRoyalties(): bool
+    {
+        return $this->has_royalties;
+    }
+
+    public function enableRoyalties(bool $has_royalties = true): self
+    {
+        $this->has_royalties = $has_royalties;
+
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getRoyaltyFee(): float
+    {
+        return $this->royalty_fee;
+    }
+
+    /**
+     * @param float $royalty_fee
+     */
+    public function setRoyaltyFee(float $royalty_fee = 0.05): self
+    {
+        $this->royalty_fee = $royalty_fee;
+
+        return $this;
+    }
+
+    /**
+     * @return float|int
+     */
+    public function getFallbackFee()
+    {
+        return $this->fallback_fee;
+    }
+
+    /**
+     * @param float|int $fallback_fee
+     */
+    public function setFallbackFee($fallback_fee = 0): self
+    {
+        $this->fallback_fee = $fallback_fee;
+
+        return $this;
+    }
+
+    /**
+     * @return String
+     */
+    public function getRoyaltyAccountId(): ?string
+    {
+        return $this->royalty_account_id;
+    }
+
+    public function setRoyaltyAccountId(string $royalty_account_id): self
+    {
+        $this->royalty_account_id = $royalty_account_id;
+
+        return $this;
+    }
+}

--- a/src/Models/NFT/NonFungibleTokenResponse.php
+++ b/src/Models/NFT/NonFungibleTokenResponse.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+class NonFungibleTokenResponse
+{
+    private String $token_id;
+
+    private String $collection_name;
+
+    private String $symbol;
+
+    private String $max_supply;
+
+    private String $treasury_id;
+
+    private bool $collection_considered_unsafe;
+
+    private array $errors = [];
+
+    /**
+     * ConsensusMessageResponse constructor, using the http response contents body object
+     * @param object $response
+     */
+    public function __construct(object $response)
+    {
+        if (property_exists($response, 'errors')) {
+            $this->errors = $response->errors;
+        } else {
+            $this->token_id = $response->data->token_id;
+            $this->collection_name = $response->data->collection_name;
+            $this->symbol = $response->data->symbol;
+            $this->max_supply = $response->data->max_supply;
+            $this->treasury_id = $response->data->treasury_id;
+            $this->collection_considered_unsafe = $response->data->collection_considered_unsafe;
+        }
+    }
+
+    /**
+     * @return String
+     */
+    public function getTokenId(): string
+    {
+        return $this->token_id;
+    }
+
+    /**
+     * @return String
+     */
+    public function getCollectionName(): string
+    {
+        return $this->collection_name;
+    }
+
+    /**
+     * @return String
+     */
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    /**
+     * @return String
+     */
+    public function getMaxSupply(): string
+    {
+        return $this->max_supply;
+    }
+
+    /**
+     * @return String
+     */
+    public function getTreasuryId(): string
+    {
+        return $this->treasury_id;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCollectionConsideredUnsafe(): bool
+    {
+        return $this->collection_considered_unsafe;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    public function isSuccessful(): bool {
+        return count($this->errors) == 0;
+    }
+}

--- a/src/Models/NFT/TransferNft.php
+++ b/src/Models/NFT/TransferNft.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+use GuzzleHttp\RequestOptions;
+
+class TransferNft
+{
+    private String $token_id;
+
+    private String $receiver_id;
+
+    private int $serial;
+
+    /**
+     * SendToken constructor.
+     *
+     * @param String $token_id
+     * @param String $receiver_id
+     * @param int $serial
+     */
+    public function __construct(string $token_id, string $receiver_id, int $serial)
+    {
+        $this->token_id = $token_id;
+        $this->receiver_id = $receiver_id;
+        $this->serial = $serial;
+    }
+
+    public function forRequest(): array
+    {
+        return [
+            RequestOptions::JSON => [
+                'token_id' => $this->getTokenId(),
+                'receiver_id' => $this->getReceiverId(),
+                'serial_number' => $this->getSerial(),
+            ]
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getTokenId(): string
+    {
+        return $this->token_id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReceiverId(): string
+    {
+        return $this->receiver_id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSerial(): int
+    {
+        return $this->serial;
+    }
+}

--- a/src/Models/NFT/TransferNftResponse.php
+++ b/src/Models/NFT/TransferNftResponse.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\NFT;
+
+class TransferNftResponse
+{
+    private String $serial_number = '';
+
+    private String $receiver_id = '';
+
+    private String $transaction_id = '';
+
+    private array $errors = [];
+
+    private bool $transfer_success = false;
+
+    /**
+     * @param object $response
+     */
+    public function __construct(object $response)
+    {
+        if (property_exists($response, 'errors')) {
+
+            error_log(json_encode($response->errors));
+            $this->errors = $response->errors;
+        } else {
+            $this->transfer_success = true;
+            $this->serial_number = $response->data->serial_number;
+            $this->transaction_id = $response->data->transaction_id;
+            $this->receiver_id = $response->data->receiver_id;
+            $this->transaction_id = $response->data->transaction_id;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasTransferSucceeded(): bool
+    {
+        return $this->transfer_success;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return String
+     */
+    public function getSerialNumber(): string
+    {
+        return $this->serial_number;
+    }
+
+    /**
+     * @return String
+     */
+    public function getReceiverId(): string
+    {
+        return $this->receiver_id;
+    }
+
+    /**
+     * @return String
+     */
+    public function getTransactionId(): string
+    {
+        return $this->transaction_id;
+    }
+
+    public function isSuccessful(): bool {
+        return count($this->errors) == 0;
+    }
+}

--- a/tests/HashgraphNftTest.php
+++ b/tests/HashgraphNftTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Tests;
+
+use Trustenterprises\LaravelHashgraph\LaravelHashgraph;
+use Trustenterprises\LaravelHashgraph\Models\NFT\ClaimNft;
+use Trustenterprises\LaravelHashgraph\Models\NFT\MintToken;
+use Trustenterprises\LaravelHashgraph\Models\NFT\NftMetadata;
+use Trustenterprises\LaravelHashgraph\Models\NFT\NonFungibleToken;
+use Trustenterprises\LaravelHashgraph\Models\NFT\TransferNft;
+
+class HashgraphNftTest extends TestCase
+{
+    /**
+     * Attempt to create an NFT
+     *
+     * @test
+     */
+    public function create_a_basic_nft()
+    {
+        $nft = new NonFungibleToken("NFT", "tNFT", 10);
+
+        $minted = LaravelHashgraph::createNonFungibleToken($nft);
+
+        $this->assertTrue(!!$minted->isSuccessful());
+        $this->assertEquals('NFT', $minted->getSymbol());
+        $this->assertEquals('tNFT', $minted->getCollectionName());
+        $this->assertEquals(10, $minted->getMaxSupply());
+    }
+
+
+    public function create_a_sad_nft()
+    {
+        $nft = new NonFungibleToken("", "", 0);
+
+        $response = LaravelHashgraph::createNonFungibleToken($nft);
+
+        $errors = $response->getErrors();
+
+        $this->assertEquals('"collection_name" is not allowed to be empty', $errors[0]);
+        $this->assertEquals('"symbol" is not allowed to be empty', $errors[1]);
+        $this->assertEquals('"supply" must be a positive number', $errors[2]);
+    }
+
+    /**
+     * Generate metadata from bad input
+     *
+     * @test
+     */
+    public function generate_bad_metadata()
+    {
+        $metadata = new NftMetadata([
+            'name_bad' => 'hello'
+        ]);
+
+        $response = LaravelHashgraph::generateMetadataForNft($metadata);
+
+        $errors = $response->getErrors();
+
+        $this->assertEquals('"name" is required', $errors[0]);
+        $this->assertEquals('"name_bad" is not allowed', $errors[1]);
+
+        $this->assertEquals('Hedera HIP412 "Strict" validation for generating valid network metadata', $response->getErrorMeta()->description);
+        $this->assertEquals('https://hips.hedera.com/hip/hip-412', $response->getErrorMeta()->url);
+    }
+
+    /**
+     * Generate metadata from bad input
+     *
+     * @test
+     */
+    public function generate_basic_metadata()
+    {
+        $metadata = new NftMetadata([
+            'name' => 'hello'
+        ]);
+
+        $response = LaravelHashgraph::generateMetadataForNft($metadata);
+
+        $this->assertTrue(!!$response->isSuccessful());
+        $this->assertTrue(!!$response->getCid());
+    }
+
+    /**
+     * Mint token from bad input
+     *
+     * @test
+     */
+    public function generate_bad_mint_no_cid()
+    {
+        $mint = new MintToken('123', '', 1);
+
+        $response = LaravelHashgraph::mintNonFungibleToken($mint);
+
+        $errors = $response->getErrors();
+
+        $this->assertEquals('"cid" is not allowed to be empty', $errors[0]);
+
+    }
+
+    /**
+     * Mint token from bad input - token
+     *
+     * @test
+     */
+    public function generate_bad_mint_no_token()
+    {
+        $mint = new MintToken('0.0.4793895911111111', 'bafkreihutncu4xpgd2q2ykfyr3xcs3vdhlih76xp6zixx4rru6ufmpxnye', 1);
+
+        $response = LaravelHashgraph::mintNonFungibleToken($mint);
+
+        $errors = $response->getErrors();
+
+        $this->assertEquals('Something went wrong, likely that the token id probably incorrect', $errors[0]);
+
+    }
+
+    /**
+     * Mint token
+     *
+     * @test
+     */
+    public function generate_mint_token()
+    {
+        $nft = new NonFungibleToken("NFT", "tNFT", 10);
+        $minted = LaravelHashgraph::createNonFungibleToken($nft);
+
+        $mint = new MintToken($minted->getTokenId(), 'bafkreihutncu4xpgd2q2ykfyr3xcs3vdhlih76xp6zixx4rru6ufmpxnye', 1);
+
+        $response = LaravelHashgraph::mintNonFungibleToken($mint);
+
+        $this->assertTrue(!!$response->isSuccessful());
+        $this->assertTrue(!!$response->getTokenId());
+        $this->assertTrue(!!$response->getAmount());
+        $this->assertTrue(!!$response->getSerialNumbers());
+    }
+
+
+
+    /**
+     * Transfer Token
+     *
+     * @test
+     */
+    public function transfer_nft_to_account()
+    {
+        $nft = new NonFungibleToken("NFT", "tNFT", 10);
+        $minted = LaravelHashgraph::createNonFungibleToken($nft);
+
+        $mint = new MintToken($minted->getTokenId(), 'bafkreihutncu4xpgd2q2ykfyr3xcs3vdhlih76xp6zixx4rru6ufmpxnye', 1);
+
+        $response = LaravelHashgraph::mintNonFungibleToken($mint);
+
+        $token_id = $response->getTokenId();
+        $serial = $response->getSerialNumbers()[0];
+
+        $account = LaravelHashgraph::createAccount();
+
+        $transfer = new TransferNft($token_id, $account->getAccountId(), $serial);
+
+        sleep(2);
+
+        $response = LaravelHashgraph::transferNonFungibleToken($transfer);
+
+        $this->assertTrue(!!$response->getSerialNumber());
+        $this->assertTrue(!!$response->getTransactionId());
+        $this->assertTrue(!!$response->getReceiverId());
+    }
+
+    /**
+     * Transfer Token
+     *
+     * @test
+     */
+    public function claim_nft_to_account()
+    {
+        $nft_pass = new NonFungibleToken("NFT_PASS", "NFT_PASS", 1);
+        $nft = new NonFungibleToken("NFT_1", "NFT_1", 1);
+
+        $minted_pass = LaravelHashgraph::createNonFungibleToken($nft_pass);
+        $minted_1 = LaravelHashgraph::createNonFungibleToken($nft);
+
+        $mint_pass = new MintToken($minted_pass->getTokenId(), 'bafkreihutncu4xpgd2q2ykfyr3xcs3vdhlih76xp6zixx4rru6ufmpxnye', 1);
+        $mint_1 = new MintToken($minted_1->getTokenId(), 'bafkreihutncu4xpgd2q2ykfyr3xcs3vdhlih76xp6zixx4rru6ufmpxnye', 1);
+
+        LaravelHashgraph::mintNonFungibleToken($mint_pass);
+        LaravelHashgraph::mintNonFungibleToken($mint_1);
+
+        $account = LaravelHashgraph::createAccount();
+
+        sleep(2);
+
+        $claim = LaravelHashgraph::claimNonFungibleToken(new ClaimNft(
+            $mint_1->getTokenId(),
+            $account->getAccountId(),
+            $mint_pass->getTokenId(),
+            1,
+        ));
+
+        $errors = $claim->getErrors();
+
+        $this->assertEquals('Unfortunately this account does not own the NFT pass required', $errors[0]);
+
+        LaravelHashgraph::transferNonFungibleToken(new TransferNft(
+            $mint_pass->getTokenId(),
+            $account->getAccountId(),
+            1
+        ));
+
+        sleep(5);
+
+        $claim = LaravelHashgraph::claimNonFungibleToken(new ClaimNft(
+            $mint_1->getTokenId(),
+            $account->getAccountId(),
+            $mint_pass->getTokenId(),
+            1,
+        ));
+
+        $this->assertTrue(!!$claim->isSuccessful());
+        $this->assertTrue(!!$claim->getSerialNumber());
+        $this->assertTrue(!!$claim->getTransactionId());
+        $this->assertTrue(!!$claim->getReceiverId());
+    }
+}


### PR DESCRIPTION
## Overview

This PR adds new methods to mirror the Trust Enterprises SDK for creating NFT ecosystems with PHP and Laravel applications.

https://docs.trust.enterprises/rest-api/nft-ecosystem

This is a breaking major release, and only supports Laravel 9 and PHP 8.1+.

