### PR TITLE
Inscription Implementation for Laravel/PHP 

### DIFF
--- a/src/Commands/LaravelHashgraphCommand.php
+++ b/src/Commands/LaravelHashgraphCommand.php
@@ -11,7 +11,7 @@ class LaravelHashgraphCommand extends Command
 
     public $description = 'My command';
 
-    public function handle()
+    public function handle(): void
     {
 //        LaravelHashgraphFacade::
 //        error_log($client->getBalance());

--- a/src/Contracts/InscriptionMethodInterface.php
+++ b/src/Contracts/InscriptionMethodInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Contracts;
+
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\BurnInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\DeployInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\MintInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\InscriptionResponse;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\TransferInscription;
+
+interface InscriptionMethodInterface
+{
+    /**
+     * @param MintInscription $request
+     * @return InscriptionResponse
+     */
+    public function deployInscription(DeployInscription $request): InscriptionResponse;
+
+    /**
+     * @param MintInscription $request
+     * @return InscriptionResponse
+     */
+    public function mintInscription(MintInscription $request): InscriptionResponse;
+
+    /**
+     * @param BurnInscription $request
+     * @return InscriptionResponse
+     */
+    public function burnInscription(BurnInscription $request): InscriptionResponse;
+
+    /**
+     * @param TransferInscription $request
+     * @return InscriptionResponse
+     */
+    public function transferInscription(TransferInscription $request): InscriptionResponse;
+}

--- a/src/Contracts/InscriptionMethodInterface.php
+++ b/src/Contracts/InscriptionMethodInterface.php
@@ -11,7 +11,8 @@ use Trustenterprises\LaravelHashgraph\Models\Inscriptions\TransferInscription;
 interface InscriptionMethodInterface
 {
     /**
-     * @param MintInscription $request
+     * @param DeployInscription $request
+     *
      * @return InscriptionResponse
      */
     public function deployInscription(DeployInscription $request): InscriptionResponse;

--- a/src/Http/Client/HashgraphClient.php
+++ b/src/Http/Client/HashgraphClient.php
@@ -348,8 +348,9 @@ class HashgraphClient implements HashgraphConsensus, InscriptionMethodInterface
 
     /**
      * HCS20 Inscription Methods
+     *
+     * @param DeployInscription $request
      */
-
     public function deployInscription(DeployInscription $request): InscriptionResponse
     {
         $response = $this->guzzle->post('api/inscription/deploy', $request->forRequest());

--- a/src/Http/Client/HashgraphClient.php
+++ b/src/Http/Client/HashgraphClient.php
@@ -6,11 +6,17 @@ namespace Trustenterprises\LaravelHashgraph\Http\Client;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Trustenterprises\LaravelHashgraph\Contracts\HashgraphConsensus;
+use Trustenterprises\LaravelHashgraph\Contracts\InscriptionMethodInterface;
 use Trustenterprises\LaravelHashgraph\Models\AccountCreateResponse;
 use Trustenterprises\LaravelHashgraph\Models\AccountHoldingsResponse;
 use Trustenterprises\LaravelHashgraph\Models\AccountTokenBalanceResponse;
 use Trustenterprises\LaravelHashgraph\Models\BequestToken;
 use Trustenterprises\LaravelHashgraph\Models\BequestTokenResponse;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\BurnInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\DeployInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\MintInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\InscriptionResponse;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\TransferInscription;
 use Trustenterprises\LaravelHashgraph\Models\NFT\BatchTransferNft;
 use Trustenterprises\LaravelHashgraph\Models\NFT\BatchTransferNftResponse;
 use Trustenterprises\LaravelHashgraph\Models\NFT\ClaimNft;
@@ -35,7 +41,7 @@ use Trustenterprises\LaravelHashgraph\Models\TopicInfo;
  * Class ServerlessHashgraphClient
  * @package Trustenterprises\LaravelHashgraph\Http\Client
  */
-class HashgraphClient implements HashgraphConsensus
+class HashgraphClient implements HashgraphConsensus, InscriptionMethodInterface
 {
     /**
      * @var Client
@@ -338,5 +344,45 @@ class HashgraphClient implements HashgraphConsensus
         $data = json_decode($response->getBody()->getContents());
 
         return new ClaimNftResponse($data);
+    }
+
+    /**
+     * HCS20 Inscription Methods
+     */
+
+    public function deployInscription(DeployInscription $request): InscriptionResponse
+    {
+        $response = $this->guzzle->post('api/inscription/deploy', $request->forRequest());
+
+        $data = json_decode($response->getBody()->getContents());
+
+        return new InscriptionResponse($data);
+    }
+
+    public function mintInscription(MintInscription $request): InscriptionResponse
+    {
+        $response = $this->guzzle->post("api/inscription/{$request->getTicker()}/mint", $request->forRequest());
+
+        $data = json_decode($response->getBody()->getContents());
+
+        return new InscriptionResponse($data);
+    }
+
+    public function burnInscription(BurnInscription $request): InscriptionResponse
+    {
+        $response = $this->guzzle->post("api/inscription/{$request->getTicker()}/burn", $request->forRequest());
+
+        $data = json_decode($response->getBody()->getContents());
+
+        return new InscriptionResponse($data);
+    }
+
+    public function transferInscription(TransferInscription $request): InscriptionResponse
+    {
+        $response = $this->guzzle->post("api/inscription/{$request->getTicker()}/transfer", $request->forRequest());
+
+        $data = json_decode($response->getBody()->getContents());
+
+        return new InscriptionResponse($data);
     }
 }

--- a/src/LaravelHashgraph.php
+++ b/src/LaravelHashgraph.php
@@ -3,6 +3,7 @@
 namespace Trustenterprises\LaravelHashgraph;
 
 use GuzzleHttp\Exception\GuzzleException;
+use Trustenterprises\LaravelHashgraph\Contracts\InscriptionMethodInterface;
 use Trustenterprises\LaravelHashgraph\Contracts\HashgraphConsensus;
 use Trustenterprises\LaravelHashgraph\Events\TopicWasCreated;
 use Trustenterprises\LaravelHashgraph\Exception\HashgraphException;
@@ -12,6 +13,11 @@ use Trustenterprises\LaravelHashgraph\Models\AccountHoldingsResponse;
 use Trustenterprises\LaravelHashgraph\Models\AccountTokenBalanceResponse;
 use Trustenterprises\LaravelHashgraph\Models\BequestToken;
 use Trustenterprises\LaravelHashgraph\Models\BequestTokenResponse;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\BurnInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\DeployInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\MintInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\InscriptionResponse;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\TransferInscription;
 use Trustenterprises\LaravelHashgraph\Models\NFT\BatchTransferNft;
 use Trustenterprises\LaravelHashgraph\Models\NFT\BatchTransferNftResponse;
 use Trustenterprises\LaravelHashgraph\Models\NFT\ClaimNft;
@@ -149,6 +155,46 @@ class LaravelHashgraph
     public static function claimNonFungibleToken(ClaimNft $claimNft) : ClaimNftResponse
     {
         return static::withAuthenticatedClient()->getClient()->claimNft($claimNft);
+    }
+
+    /**
+     * Deploy a new inscription
+     *
+     * @throws GuzzleException
+     */
+    public static function deployInscription(DeployInscription $deployInscription) : InscriptionResponse
+    {
+        return static::withAuthenticatedClient()->getClient()->deployInscription($deployInscription);
+    }
+
+    /**
+     * Mint a new inscription
+     *
+     * @throws GuzzleException
+     */
+    public static function mintInscription(MintInscription $mintInscription) : InscriptionResponse
+    {
+        return static::withAuthenticatedClient()->getClient()->mintInscription($mintInscription);
+    }
+
+    /**
+     * Burn a inscription
+     *
+     * @throws GuzzleException
+     */
+    public static function burnInscription(BurnInscription $burnInscription) : InscriptionResponse
+    {
+        return static::withAuthenticatedClient()->getClient()->burnInscription($burnInscription);
+    }
+
+    /**
+     * Transfer a inscription
+     *
+     * @throws GuzzleException
+     */
+    public static function transferInscription(TransferInscription $transferInscription) : InscriptionResponse
+    {
+        return static::withAuthenticatedClient()->getClient()->transferInscription($transferInscription);
     }
 
     /**
@@ -292,7 +338,7 @@ class LaravelHashgraph
     /**
      * @return HashgraphClient
      */
-    public function getClient(): HashgraphConsensus
+    public function getClient(): InscriptionMethodInterface
     {
         return $this->client;
     }

--- a/src/LaravelHashgraphServiceProvider.php
+++ b/src/LaravelHashgraphServiceProvider.php
@@ -11,7 +11,7 @@ class LaravelHashgraphServiceProvider extends ServiceProvider
 {
     const HASHGRAPH_SERVICE_NAME = 'hashgraph_trust';
 
-    public function boot()
+    public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([

--- a/src/Listeners/UpdateExplorerUrl.php
+++ b/src/Listeners/UpdateExplorerUrl.php
@@ -6,7 +6,7 @@ use Trustenterprises\LaravelHashgraph\Events\ConsensusMessageWasReceived;
 
 class UpdateExplorerUrl
 {
-    public function handle(ConsensusMessageWasReceived $event)
+    public function handle(ConsensusMessageWasReceived $event): void
     {
         $event->consensus_message->update([
            'explorer_url' => 'https://trust.enterprises/',

--- a/src/Models/Inscriptions/BurnInscription.php
+++ b/src/Models/Inscriptions/BurnInscription.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\Inscriptions;
+
+use GuzzleHttp\RequestOptions;
+
+class BurnInscription
+{
+    private String $from;
+
+    private int $amount;
+
+    private String $ticker;
+
+    private ?String $memo = null;
+
+    private ?String $topic_id = null;
+
+    /**
+     * FungibleToken constructor.
+     * @param string $ticker
+     * @param string $from
+     * @param int $amount
+     */
+    public function __construct(string $ticker, string $from, int $amount)
+    {
+        $this->ticker = $ticker;
+        $this->from = $from;
+        $this->amount = $amount;
+    }
+
+    public function forRequest(): array
+    {
+        $payload = [
+            'from' => $this->getFrom(),
+            'amount' => $this->getAmount(),
+        ];
+
+        if ($this->getMemo()) {
+            $payload['memo'] = $this->getMemo();
+        }
+
+        if ($this->getPrivateTopicId()) {
+            $payload['topic_id'] = $this->getPrivateTopicId();
+        }
+
+        return [ RequestOptions::JSON => $payload ];
+    }
+
+    /**
+     * @return String|string
+     */
+    public function getTicker()
+    {
+        return $this->ticker;
+    }
+
+    /**
+     * @param String|string $ticker
+     */
+    public function setTicker($ticker)
+    {
+        $this->ticker = $ticker;
+    }
+
+    /**
+     * @return String
+     */
+    public function getMemo()
+    {
+        return $this->memo;
+    }
+
+    /**
+     * @param String $memo
+     */
+    public function setMemo($memo)
+    {
+        $this->memo = $memo;
+    }
+
+    /**
+     * @return String
+     */
+    public function getPrivateTopicId()
+    {
+        return $this->topic_id;
+    }
+
+    /**
+     * @param String $topic_id
+     */
+    public function setPrivateTopic($topic_id)
+    {
+        $this->topic_id = $topic_id;
+    }
+
+    /**
+     * @return string|string
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    /**
+     * @param string|string $from
+     */
+    public function setFrom($from)
+    {
+        $this->from = $from;
+    }
+
+    /**
+     * @return int|int
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param int|int $amount
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+    }
+}
+

--- a/src/Models/Inscriptions/BurnInscription.php
+++ b/src/Models/Inscriptions/BurnInscription.php
@@ -58,15 +58,15 @@ class BurnInscription
     /**
      * @param String|string $ticker
      */
-    public function setTicker($ticker)
+    public function setTicker($ticker): void
     {
         $this->ticker = $ticker;
     }
 
     /**
-     * @return String
+     * @return null|string
      */
-    public function getMemo()
+    public function getMemo(): string|null
     {
         return $this->memo;
     }
@@ -74,15 +74,15 @@ class BurnInscription
     /**
      * @param String $memo
      */
-    public function setMemo($memo)
+    public function setMemo($memo): void
     {
         $this->memo = $memo;
     }
 
     /**
-     * @return String
+     * @return null|string
      */
-    public function getPrivateTopicId()
+    public function getPrivateTopicId(): string|null
     {
         return $this->topic_id;
     }
@@ -90,7 +90,7 @@ class BurnInscription
     /**
      * @param String $topic_id
      */
-    public function setPrivateTopic($topic_id)
+    public function setPrivateTopic($topic_id): void
     {
         $this->topic_id = $topic_id;
     }
@@ -106,7 +106,7 @@ class BurnInscription
     /**
      * @param string|string $from
      */
-    public function setFrom($from)
+    public function setFrom($from): void
     {
         $this->from = $from;
     }
@@ -122,7 +122,7 @@ class BurnInscription
     /**
      * @param int|int $amount
      */
-    public function setAmount($amount)
+    public function setAmount($amount): void
     {
         $this->amount = $amount;
     }

--- a/src/Models/Inscriptions/DeployInscription.php
+++ b/src/Models/Inscriptions/DeployInscription.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\Inscriptions;
+
+use GuzzleHttp\RequestOptions;
+
+class DeployInscription
+{
+    private String $name;
+
+    private String $ticker;
+
+    private int $max;
+
+    private ?int $limit = null;
+
+    private ?String $metadata = null;
+
+    private ?String $memo = null;
+
+    private ?String $topic_id = null;
+
+    /**
+     * FungibleToken constructor.
+     * @param string $ticker
+     * @param string $name
+     * @param int $max
+     */
+    public function __construct(string $ticker, string $name, int $max)
+    {
+        $this->ticker = $ticker;
+        $this->name = $name;
+        $this->max = $max;
+    }
+
+    public function forRequest(): array
+    {
+        $payload = [
+            'ticker' => $this->getTicker(),
+            'name' => $this->getName(),
+            'max' => $this->getMax(),
+        ];
+
+        if ($this->getLimit()) {
+            $payload['limit'] = $this->getLimit();
+        }
+
+        if ($this->getMemo()) {
+            $payload['memo'] = $this->getMemo();
+        }
+
+        if ($this->getMetadata()) {
+            $payload['metadata'] = $this->getMetadata();
+        }
+
+        if ($this->getPrivateTopicId()) {
+            $payload['topic_id'] = $this->getPrivateTopicId();
+        }
+
+        return [ RequestOptions::JSON => $payload ];
+    }
+
+    /**
+     * @return String|string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param String|string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return String|string
+     */
+    public function getTicker()
+    {
+        return $this->ticker;
+    }
+
+    /**
+     * @param String|string $ticker
+     */
+    public function setTicker($ticker)
+    {
+        $this->ticker = $ticker;
+    }
+
+    /**
+     * @return int|Integer
+     */
+    public function getMax()
+    {
+        return $this->max;
+    }
+
+    /**
+     * @param int|Integer $max
+     */
+    public function setMax($max)
+    {
+        $this->max = $max;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLimit()
+    {
+        return $this->limit;
+    }
+
+    /**
+     * @param int $limit
+     */
+    public function setLimit($limit)
+    {
+        $this->limit = $limit;
+    }
+
+    /**
+     * @return String
+     */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @param String $metadata
+     */
+    public function setMetadata($metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * @return String
+     */
+    public function getMemo()
+    {
+        return $this->memo;
+    }
+
+    /**
+     * @param String $memo
+     */
+    public function setMemo($memo)
+    {
+        $this->memo = $memo;
+    }
+
+    /**
+     * @return String
+     */
+    public function getPrivateTopicId()
+    {
+        return $this->topic_id;
+    }
+
+    /**
+     * @param String $topic_id
+     */
+    public function setPrivateTopic($topic_id)
+    {
+        $this->topic_id = $topic_id;
+    }
+}
+

--- a/src/Models/Inscriptions/DeployInscription.php
+++ b/src/Models/Inscriptions/DeployInscription.php
@@ -93,7 +93,7 @@ class DeployInscription
     }
 
     /**
-     * @return int|Integer
+     * @return int
      */
     public function getMax()
     {
@@ -101,7 +101,7 @@ class DeployInscription
     }
 
     /**
-     * @param int|Integer $max
+     * @param int $max
      */
     public function setMax($max): void
     {

--- a/src/Models/Inscriptions/DeployInscription.php
+++ b/src/Models/Inscriptions/DeployInscription.php
@@ -71,7 +71,7 @@ class DeployInscription
     /**
      * @param String|string $name
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -87,7 +87,7 @@ class DeployInscription
     /**
      * @param String|string $ticker
      */
-    public function setTicker($ticker)
+    public function setTicker($ticker): void
     {
         $this->ticker = $ticker;
     }
@@ -103,15 +103,12 @@ class DeployInscription
     /**
      * @param int|Integer $max
      */
-    public function setMax($max)
+    public function setMax($max): void
     {
         $this->max = $max;
     }
 
-    /**
-     * @return int
-     */
-    public function getLimit()
+    public function getLimit(): int|null
     {
         return $this->limit;
     }
@@ -119,15 +116,15 @@ class DeployInscription
     /**
      * @param int $limit
      */
-    public function setLimit($limit)
+    public function setLimit($limit): void
     {
         $this->limit = $limit;
     }
 
     /**
-     * @return String
+     * @return null|string
      */
-    public function getMetadata()
+    public function getMetadata(): string|null
     {
         return $this->metadata;
     }
@@ -135,15 +132,15 @@ class DeployInscription
     /**
      * @param String $metadata
      */
-    public function setMetadata($metadata)
+    public function setMetadata($metadata): void
     {
         $this->metadata = $metadata;
     }
 
     /**
-     * @return String
+     * @return null|string
      */
-    public function getMemo()
+    public function getMemo(): string|null
     {
         return $this->memo;
     }
@@ -151,15 +148,15 @@ class DeployInscription
     /**
      * @param String $memo
      */
-    public function setMemo($memo)
+    public function setMemo($memo): void
     {
         $this->memo = $memo;
     }
 
     /**
-     * @return String
+     * @return null|string
      */
-    public function getPrivateTopicId()
+    public function getPrivateTopicId(): string|null
     {
         return $this->topic_id;
     }
@@ -167,7 +164,7 @@ class DeployInscription
     /**
      * @param String $topic_id
      */
-    public function setPrivateTopic($topic_id)
+    public function setPrivateTopic($topic_id): void
     {
         $this->topic_id = $topic_id;
     }

--- a/src/Models/Inscriptions/InscriptionResponse.php
+++ b/src/Models/Inscriptions/InscriptionResponse.php
@@ -1,0 +1,102 @@
+<?php
+
+
+namespace Trustenterprises\LaravelHashgraph\Models\Inscriptions;
+
+/**
+ * {
+        "data": {
+            "topic_id": "7459744",
+            "transaction_id": "0.0.135908@1704558798.734620091",
+            "explorer_url": "https://ledger-testnet.hashlog.io/tx/0.0.135908@1704558798.734620091",
+            "inscription": {
+                "p": "hcs-20",
+                "op": "mint",
+                "tick": "TICK",
+                "amt": "1",
+                "to": "0.0.1156"
+            }
+        }
+ * }
+ */
+
+class InscriptionResponse
+{
+    private String $topic_id;
+
+    private String $transaction_id;
+
+    private String $explorer_url;
+
+    private object $inscription;
+
+    private array $errors = [];
+
+    private bool $transfer_success = false;
+
+    /**
+     * ConsensusMessageResponse constructor, using the http response contents body object
+     * @param object $response
+     */
+    public function __construct(object $response)
+    {
+
+        if (property_exists($response, 'errors')) {
+            $this->errors = $response->errors;
+        } else {
+            $this->transfer_success = true;
+            $this->topic_id = $response->data->topic_id;
+            $this->transaction_id = $response->data->transaction_id;
+            $this->explorer_url = $response->data->explorer_url;
+            $this->inscription = (object) $response->data->inscription;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasSucceeded(): bool
+    {
+        return $this->transfer_success;
+    }
+
+    /**
+     * @return String
+     */
+    public function getTopicId(): String
+    {
+        return $this->topic_id;
+    }
+
+    /**
+     * @return String
+     */
+    public function getTransactionId(): string
+    {
+        return $this->transaction_id;
+    }
+
+    /**
+     * @return String
+     */
+    public function getExplorerUrl(): string
+    {
+        return $this->explorer_url;
+    }
+
+    /**
+     * @return object
+     */
+    public function getInscription(): object
+    {
+        return $this->inscription;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Models/Inscriptions/MintInscription.php
+++ b/src/Models/Inscriptions/MintInscription.php
@@ -58,15 +58,15 @@ class MintInscription
     /**
      * @param String|string $ticker
      */
-    public function setTicker($ticker)
+    public function setTicker($ticker): void
     {
         $this->ticker = $ticker;
     }
 
     /**
-     * @return String
+     * @return null|string
      */
-    public function getMemo()
+    public function getMemo(): string|null
     {
         return $this->memo;
     }
@@ -74,15 +74,15 @@ class MintInscription
     /**
      * @param String $memo
      */
-    public function setMemo($memo)
+    public function setMemo($memo): void
     {
         $this->memo = $memo;
     }
 
     /**
-     * @return String
+     * @return null|string
      */
-    public function getPrivateTopicId()
+    public function getPrivateTopicId(): string|null
     {
         return $this->topic_id;
     }
@@ -90,7 +90,7 @@ class MintInscription
     /**
      * @param String $topic_id
      */
-    public function setPrivateTopic($topic_id)
+    public function setPrivateTopic($topic_id): void
     {
         $this->topic_id = $topic_id;
     }
@@ -106,7 +106,7 @@ class MintInscription
     /**
      * @param string|string $to
      */
-    public function setTo($to)
+    public function setTo($to): void
     {
         $this->to = $to;
     }
@@ -122,7 +122,7 @@ class MintInscription
     /**
      * @param int|int $amount
      */
-    public function setAmount($amount)
+    public function setAmount($amount): void
     {
         $this->amount = $amount;
     }

--- a/src/Models/Inscriptions/MintInscription.php
+++ b/src/Models/Inscriptions/MintInscription.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\Inscriptions;
+
+use GuzzleHttp\RequestOptions;
+
+class MintInscription
+{
+    private String $to;
+
+    private int $amount;
+
+    private String $ticker;
+
+    private ?String $memo = null;
+
+    private ?String $topic_id = null;
+
+    /**
+     * FungibleToken constructor.
+     * @param string $ticker
+     * @param string $to
+     * @param int $amount
+     s*/
+    public function __construct(string $ticker, string $to, int $amount)
+    {
+        $this->ticker = $ticker;
+        $this->to = $to;
+        $this->amount = $amount;
+    }
+
+    public function forRequest(): array
+    {
+        $payload = [
+            'to' => $this->getTo(),
+            'amount' => $this->getAmount(),
+        ];
+
+        if ($this->getMemo()) {
+            $payload['memo'] = $this->getMemo();
+        }
+
+        if ($this->getPrivateTopicId()) {
+            $payload['topic_id'] = $this->getPrivateTopicId();
+        }
+
+        return [ RequestOptions::JSON => $payload ];
+    }
+
+    /**
+     * @return String|string
+     */
+    public function getTicker()
+    {
+        return $this->ticker;
+    }
+
+    /**
+     * @param String|string $ticker
+     */
+    public function setTicker($ticker)
+    {
+        $this->ticker = $ticker;
+    }
+
+    /**
+     * @return String
+     */
+    public function getMemo()
+    {
+        return $this->memo;
+    }
+
+    /**
+     * @param String $memo
+     */
+    public function setMemo($memo)
+    {
+        $this->memo = $memo;
+    }
+
+    /**
+     * @return String
+     */
+    public function getPrivateTopicId()
+    {
+        return $this->topic_id;
+    }
+
+    /**
+     * @param String $topic_id
+     */
+    public function setPrivateTopic($topic_id)
+    {
+        $this->topic_id = $topic_id;
+    }
+
+    /**
+     * @return string|string
+     */
+    public function getTo()
+    {
+        return $this->to;
+    }
+
+    /**
+     * @param string|string $to
+     */
+    public function setTo($to)
+    {
+        $this->to = $to;
+    }
+
+    /**
+     * @return int|int
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param int|int $amount
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+    }
+}
+

--- a/src/Models/Inscriptions/TransferInscription.php
+++ b/src/Models/Inscriptions/TransferInscription.php
@@ -63,15 +63,15 @@ class TransferInscription
     /**
      * @param String|string $ticker
      */
-    public function setTicker($ticker)
+    public function setTicker($ticker): void
     {
         $this->ticker = $ticker;
     }
 
     /**
-     * @return String
+     * @return null|string
      */
-    public function getMemo()
+    public function getMemo(): string|null
     {
         return $this->memo;
     }
@@ -79,15 +79,15 @@ class TransferInscription
     /**
      * @param String $memo
      */
-    public function setMemo($memo)
+    public function setMemo($memo): void
     {
         $this->memo = $memo;
     }
 
     /**
-     * @return String
+     * @return null|string
      */
-    public function getPrivateTopicId()
+    public function getPrivateTopicId(): string|null
     {
         return $this->topic_id;
     }
@@ -95,7 +95,7 @@ class TransferInscription
     /**
      * @param String $topic_id
      */
-    public function setPrivateTopic($topic_id)
+    public function setPrivateTopic($topic_id): void
     {
         $this->topic_id = $topic_id;
     }
@@ -111,7 +111,7 @@ class TransferInscription
     /**
      * @param string|string $from
      */
-    public function setFrom($from)
+    public function setFrom($from): void
     {
         $this->from = $from;
     }
@@ -127,7 +127,7 @@ class TransferInscription
     /**
      * @param string|string $to
      */
-    public function setTo($to)
+    public function setTo($to): void
     {
         $this->to = $to;
     }
@@ -143,7 +143,7 @@ class TransferInscription
     /**
      * @param int|int $amount
      */
-    public function setAmount($amount)
+    public function setAmount($amount): void
     {
         $this->amount = $amount;
     }

--- a/src/Models/Inscriptions/TransferInscription.php
+++ b/src/Models/Inscriptions/TransferInscription.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Models\Inscriptions;
+
+use GuzzleHttp\RequestOptions;
+
+class TransferInscription
+{
+    private String $from;
+
+    private String $to;
+
+    private int $amount;
+
+    private String $ticker;
+
+    private ?String $memo = null;
+
+    private ?String $topic_id = null;
+
+    /**
+     * FungibleToken constructor.
+     * @param string $ticker
+     * @param string $from
+     * @param string $to
+     * @param int $amount
+     */
+    public function __construct(string $ticker, string $from, string $to, int $amount)
+    {
+        $this->ticker = $ticker;
+        $this->from = $from;
+        $this->to = $to;
+        $this->amount = $amount;
+    }
+
+    public function forRequest(): array
+    {
+        $payload = [
+            'from' => $this->getFrom(),
+            'to' => $this->getTo(),
+            'amount' => $this->getAmount(),
+        ];
+
+        if ($this->getMemo()) {
+            $payload['memo'] = $this->getMemo();
+        }
+
+        if ($this->getPrivateTopicId()) {
+            $payload['topic_id'] = $this->getPrivateTopicId();
+        }
+
+        return [ RequestOptions::JSON => $payload ];
+    }
+
+    /**
+     * @return String|string
+     */
+    public function getTicker()
+    {
+        return $this->ticker;
+    }
+
+    /**
+     * @param String|string $ticker
+     */
+    public function setTicker($ticker)
+    {
+        $this->ticker = $ticker;
+    }
+
+    /**
+     * @return String
+     */
+    public function getMemo()
+    {
+        return $this->memo;
+    }
+
+    /**
+     * @param String $memo
+     */
+    public function setMemo($memo)
+    {
+        $this->memo = $memo;
+    }
+
+    /**
+     * @return String
+     */
+    public function getPrivateTopicId()
+    {
+        return $this->topic_id;
+    }
+
+    /**
+     * @param String $topic_id
+     */
+    public function setPrivateTopic($topic_id)
+    {
+        $this->topic_id = $topic_id;
+    }
+
+    /**
+     * @return string|string
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    /**
+     * @param string|string $from
+     */
+    public function setFrom($from)
+    {
+        $this->from = $from;
+    }
+
+    /**
+     * @return string|string
+     */
+    public function getTo()
+    {
+        return $this->to;
+    }
+
+    /**
+     * @param string|string $to
+     */
+    public function setTo($to)
+    {
+        $this->to = $to;
+    }
+
+    /**
+     * @return int|int
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param int|int $amount
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+    }
+}
+

--- a/src/Models/TopicInfo.php
+++ b/src/Models/TopicInfo.php
@@ -21,7 +21,7 @@ class TopicInfo
         $this->topic_id = $topic_id;
     }
 
-    public static function emptyTopic()
+    public static function emptyTopic(): self
     {
         return new self('', self::EMPTY_TOPIC_ID);
     }

--- a/src/Utilities/ConvertToProofId.php
+++ b/src/Utilities/ConvertToProofId.php
@@ -10,7 +10,7 @@ class ConvertToProofId
      * @param $transaction_id
      * @return string
      */
-    public static function create($transaction_id): string
+    public static function create(string $transaction_id): string
     {
         $split_tx = explode('@', $transaction_id);
         $ts = explode('.', $split_tx[1]);

--- a/src/Utilities/Hmac.php
+++ b/src/Utilities/Hmac.php
@@ -11,7 +11,7 @@ class Hmac
      * @param $content
      * @return string
      */
-    public static function generate($content): string
+    public static function generate(string $content): string
     {
         return hash_hmac('sha256', $content, config('hashgraph.secret_key'));
     }

--- a/tests/HashgraphInscriptionTest.php
+++ b/tests/HashgraphInscriptionTest.php
@@ -28,11 +28,11 @@ class HashgraphInscriptionTest extends TestCase
 
         $deploy->setPrivateTopic(self::$TOPIC_ID);
 
-        $minted = LaravelHashgraph::deployInscription($deploy);
+        $result = LaravelHashgraph::deployInscription($deploy);
 
-        $inscription = $minted->getInscription();
+        $inscription = $result->getInscription();
 
-        $this->assertTrue($minted->hasSucceeded());
+        $this->assertTrue($result->hasSucceeded());
 
         $this->assertEquals(300, $inscription->max);
         $this->assertEquals('TICK1', $inscription->tick);
@@ -52,11 +52,11 @@ class HashgraphInscriptionTest extends TestCase
 
         $mint->setPrivateTopic(self::$TOPIC_ID);
 
-        $minted = LaravelHashgraph::mintInscription($mint);
+        $result = LaravelHashgraph::mintInscription($mint);
 
-        $inscription = $minted->getInscription();
+        $inscription = $result->getInscription();
 
-        $this->assertTrue($minted->hasSucceeded());
+        $this->assertTrue($result->hasSucceeded());
 
         $this->assertEquals('TICK1', $inscription->tick);
         $this->assertEquals('0.0.1', $inscription->to);
@@ -77,11 +77,11 @@ class HashgraphInscriptionTest extends TestCase
 
         $burn->setPrivateTopic(self::$TOPIC_ID);
 
-        $minted = LaravelHashgraph::burnInscription($burn);
+        $result = LaravelHashgraph::burnInscription($burn);
 
-        $inscription = $minted->getInscription();
+        $inscription = $result->getInscription();
 
-        $this->assertTrue($minted->hasSucceeded());
+        $this->assertTrue($result->hasSucceeded());
 
         $this->assertEquals('TICK1', $inscription->tick);
         $this->assertEquals('0.0.1', $inscription->from);
@@ -101,11 +101,11 @@ class HashgraphInscriptionTest extends TestCase
 
         $transfer->setPrivateTopic(self::$TOPIC_ID);
 
-        $minted = LaravelHashgraph::transferInscription($transfer);
+        $result = LaravelHashgraph::transferInscription($transfer);
 
-        $inscription = $minted->getInscription();
+        $inscription = $result->getInscription();
 
-        $this->assertTrue($minted->hasSucceeded());
+        $this->assertTrue($result->hasSucceeded());
 
         $this->assertEquals('TICK1', $inscription->tick);
         $this->assertEquals('0.0.1', $inscription->from);

--- a/tests/HashgraphInscriptionTest.php
+++ b/tests/HashgraphInscriptionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Trustenterprises\LaravelHashgraph\Tests;
+
+use Trustenterprises\LaravelHashgraph\LaravelHashgraph;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\BurnInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\DeployInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\MintInscription;
+use Trustenterprises\LaravelHashgraph\Models\Inscriptions\TransferInscription;
+use Trustenterprises\LaravelHashgraph\Models\NFT\ClaimNft;
+use Trustenterprises\LaravelHashgraph\Models\NFT\MintToken;
+use Trustenterprises\LaravelHashgraph\Models\NFT\NftMetadata;
+use Trustenterprises\LaravelHashgraph\Models\NFT\NonFungibleToken;
+use Trustenterprises\LaravelHashgraph\Models\NFT\TransferNft;
+
+class HashgraphInscriptionTest extends TestCase
+{
+    private static $TOPIC_ID = "7459744";
+
+    /**
+     * Attempt to deploy an inscription
+     *
+     * @test
+     */
+    public function deploy_an_inscription()
+    {
+        $deploy = new DeployInscription('TICK1', 'Ticker', 300);
+
+        $deploy->setPrivateTopic(self::$TOPIC_ID);
+
+        $minted = LaravelHashgraph::deployInscription($deploy);
+
+        $inscription = $minted->getInscription();
+
+        $this->assertTrue($minted->hasSucceeded());
+
+        $this->assertEquals(300, $inscription->max);
+        $this->assertEquals('TICK1', $inscription->tick);
+        $this->assertEquals('Ticker', $inscription->name);
+        $this->assertEquals('deploy', $inscription->op);
+        $this->assertEquals('hcs-20', $inscription->p);
+    }
+
+    /**
+     * Attempt to mint an inscription
+     *
+     * @test
+     */
+    public function mint_an_inscription()
+    {
+        $mint = new MintInscription('TICK1', '0.0.1', 1);
+
+        $mint->setPrivateTopic(self::$TOPIC_ID);
+
+        $minted = LaravelHashgraph::mintInscription($mint);
+
+        $inscription = $minted->getInscription();
+
+        $this->assertTrue($minted->hasSucceeded());
+
+        $this->assertEquals('TICK1', $inscription->tick);
+        $this->assertEquals('0.0.1', $inscription->to);
+        $this->assertEquals(1, $inscription->amt);
+        $this->assertEquals('mint', $inscription->op);
+        $this->assertEquals('hcs-20', $inscription->p);
+    }
+
+
+    /**
+     * Attempt to burn an inscription
+     *
+     * @test
+     */
+    public function burn_an_inscription()
+    {
+        $burn = new BurnInscription('TICK1', '0.0.1', 1);
+
+        $burn->setPrivateTopic(self::$TOPIC_ID);
+
+        $minted = LaravelHashgraph::burnInscription($burn);
+
+        $inscription = $minted->getInscription();
+
+        $this->assertTrue($minted->hasSucceeded());
+
+        $this->assertEquals('TICK1', $inscription->tick);
+        $this->assertEquals('0.0.1', $inscription->from);
+        $this->assertEquals(1, $inscription->amt);
+        $this->assertEquals('burn', $inscription->op);
+        $this->assertEquals('hcs-20', $inscription->p);
+    }
+
+    /**
+     * Attempt to transfer an inscription
+     *
+     * @test
+     */
+    public function transfer_a_inscription()
+    {
+        $transfer = new TransferInscription('TICK1', '0.0.1', '0.0.2', 1);
+
+        $transfer->setPrivateTopic(self::$TOPIC_ID);
+
+        $minted = LaravelHashgraph::transferInscription($transfer);
+
+        $inscription = $minted->getInscription();
+
+        $this->assertTrue($minted->hasSucceeded());
+
+        $this->assertEquals('TICK1', $inscription->tick);
+        $this->assertEquals('0.0.1', $inscription->from);
+        $this->assertEquals('0.0.2', $inscription->to);
+        $this->assertEquals(1, $inscription->amt);
+        $this->assertEquals('transfer', $inscription->op);
+        $this->assertEquals('hcs-20', $inscription->p);
+    }
+}


### PR DESCRIPTION
## Overview

This provides inscription capibility for PHP, you can view the tests where appropriate but the features mirror the inscription API for:

- deploying
- minting
- burning
- transferring 

Every response through the Inscription methods will return a **InscriptionResponse** object that includes the raw inscription data and related consensus message ids for storage.

## Deploy

The constructor expects the default values, you can set private topics or memo/metadata/limits as appropriate for any particular **inscriptionRequest** class.

```
$deploy = new DeployInscription('TICK1', 'Ticker', 300);
$deploy->setPrivateTopic(self::$TOPIC_ID);

$minted = LaravelHashgraph::deployInscription($deploy);
```

## Mint

```
$mint = new MintInscription('TICK1', '0.0.1', 1);
$mint->setPrivateTopic(self::$TOPIC_ID);

$minted = LaravelHashgraph::mintInscription($mint);
```


## Burn

```
$burn = new BurnInscription('TICK1', '0.0.1', 1);
$burn->setPrivateTopic(self::$TOPIC_ID);

$minted = LaravelHashgraph::burnInscription($burn);
```


## Transfer

```
$transfer = new TransferInscription('TICK1', '0.0.1', '0.0.2', 1);
$transfer->setPrivateTopic(self::$TOPIC_ID);

$minted = LaravelHashgraph::transferInscription($transfer);
```